### PR TITLE
fixed missing duration for some video formats

### DIFF
--- a/internal/thumb/draw.go
+++ b/internal/thumb/draw.go
@@ -2,14 +2,15 @@ package thumb
 
 import (
 	"fmt"
+	"image"
+	"io/fs"
+	"path/filepath"
+
 	"github.com/gookit/goutil/fsutil"
 	"github.com/kmou424/go-video-thumb/internal/global"
 	"github.com/kmou424/go-video-thumb/internal/tool"
 	"github.com/kmou424/go-video-thumb/internal/tool/imgtool"
 	"github.com/kmou424/go-video-thumb/internal/tool/vidtool"
-	"image"
-	"io/fs"
-	"path/filepath"
 )
 
 var (
@@ -67,6 +68,9 @@ func Draw() {
 
 func drawVideoThumb(videoFile string) {
 	for _, streamInfo := range videoInfo.StreamInfos {
+		if streamInfo.ExpDuration == "" {
+			streamInfo.ExpDuration = videoInfo.FormatInfo.Duration
+		}
 		switch streamInfo.Type {
 		case "video":
 			vStream = *streamInfo.AsStream()

--- a/internal/tool/vidtool/info.go
+++ b/internal/tool/vidtool/info.go
@@ -3,11 +3,12 @@ package vidtool
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
+
 	"github.com/gookit/goutil/mathutil"
 	"github.com/kmou424/go-video-thumb/internal/tool"
 	"github.com/kmou424/go-video-thumb/internal/tool/mathtool"
 	ffmpeg "github.com/u2takey/ffmpeg-go"
-	"path/filepath"
 )
 
 type Stream struct {
@@ -23,6 +24,12 @@ type Stream struct {
 	PixelFormat        string
 }
 
+type VideoInfo struct {
+	StreamInfos []StreamInfo `json:"streams"`
+	FormatInfo  `json:"format"`
+	FileName    string `json:"-"`
+}
+
 type StreamInfo struct {
 	Type               string `json:"codec_type"`
 	Codec              string `json:"codec_name"`
@@ -34,6 +41,11 @@ type StreamInfo struct {
 	ExpDuration        string `json:"duration"`
 	ExpRFrameRate      string `json:"r_frame_rate"`
 	PixelFormat        string `json:"pix_fmt"`
+}
+
+type FormatInfo struct {
+	Size     string `json:"size"`
+	Duration string `json:"duration"`
 }
 
 func (s *StreamInfo) AsStream() *Stream {
@@ -73,16 +85,6 @@ func (s *StreamInfo) AsStream() *Stream {
 		}(),
 		PixelFormat: s.PixelFormat,
 	}
-}
-
-type FormatInfo struct {
-	Size string `json:"size"`
-}
-
-type VideoInfo struct {
-	StreamInfos []StreamInfo `json:"streams"`
-	FormatInfo  `json:"format"`
-	FileName    string `json:"-"`
 }
 
 func (v *VideoInfo) FormatSize() map[string]string {


### PR DESCRIPTION
Some video formats, like mkv, do not have a `duration` field in their individual A/V streams. The current code therefor panics out. A duration field is present in the general format object though. This small update attempts to pull in the duration from that format object if it is missing on the individual stream. 